### PR TITLE
Add audio track info to dash manifest, if present

### DIFF
--- a/src/invidious/routes/api/manifest.cr
+++ b/src/invidious/routes/api/manifest.cr
@@ -70,17 +70,22 @@ module Invidious::Routes::API::Manifest
               # OTF streams aren't supported yet (See https://github.com/TeamNewPipe/NewPipe/issues/2415)
               next if !(fmt.has_key?("indexRange") && fmt.has_key?("initRange"))
 
+              audio_track = fmt["audioTrack"]?.try &.as_h? || {} of String => JSON::Any
+              lang = audio_track["id"]?.try &.as_s.split('.')[0] || "und"
+              is_default = audio_track.has_key?("audioIsDefault") ? audio_track["audioIsDefault"].as_bool : i == 0
+              displayname = audio_track["displayName"]?.try &.as_s || "Unknown"
+
               # Different representations of the same audio should be groupped into one AdaptationSet.
               # However, most players don't support auto quality switching, so we have to trick them
               # into providing a quality selector.
               # See https://github.com/iv-org/invidious/issues/3074 for more details.
-              xml.element("AdaptationSet", id: i, mimeType: mime_type, startWithSAP: 1, subsegmentAlignment: true, label: fmt["bitrate"].to_s + "k") do
+              xml.element("AdaptationSet", id: i, mimeType: mime_type, startWithSAP: 1, subsegmentAlignment: true, label: displayname, lang: lang) do
                 codecs = fmt["mimeType"].as_s.split("codecs=")[1].strip('"')
                 bandwidth = fmt["bitrate"].as_i
                 itag = fmt["itag"].as_i
                 url = fmt["url"].as_s
 
-                xml.element("Role", schemeIdUri: "urn:mpeg:dash:role:2011", value: i == 0 ? "main" : "alternate")
+                xml.element("Role", schemeIdUri: "urn:mpeg:dash:role:2011", value: is_default ? "main" : "alternate")
 
                 xml.element("Representation", id: fmt["itag"], codecs: codecs, bandwidth: bandwidth) do
                   xml.element("AudioChannelConfiguration", schemeIdUri: "urn:mpeg:dash:23003:3:audio_channel_configuration:2011",

--- a/src/invidious/videos.cr
+++ b/src/invidious/videos.cr
@@ -106,7 +106,7 @@ struct Video
     if formats = info.dig?("streamingData", "adaptiveFormats")
       return formats
         .as_a.map(&.as_h)
-        .sort_by! { |f| f["width"]?.try &.as_i || 0 }
+        .sort_by! { |f| f["width"]?.try &.as_i || f["audioTrack"]?.try { |a| a["audioIsDefault"]?.try { |v| v.as_bool ? -1 : 0 } } || 0 }
     else
       return [] of Hash(String, JSON::Any)
     end


### PR DESCRIPTION
  - language id
  - language display name
  - main/default track Sort audio formats so that main/default is first (for clients not using dash)

* Note: this should be a non-breaking change; if audio track info is not availablle, the behavior does not change from current